### PR TITLE
Fix Vue3 compatibility issues [BP-21148]

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -179,7 +179,7 @@ var doCheck = function (force) {
 };
 
 export default {
-  bind(el, binding, vnode) {
+  beforeMount(el, binding, vnode) {
     el[ctx] = {
       el,
       vm: vnode.context,
@@ -209,7 +209,7 @@ export default {
     });
   },
 
-  unbind(el) {
+  unmounted(el) {
     if (el && el[ctx] && el[ctx].scrollEventTarget)
       el[ctx].scrollEventTarget.removeEventListener('scroll', el[ctx].scrollListener);
   }

--- a/src/directive.js
+++ b/src/directive.js
@@ -107,9 +107,9 @@ var doBind = function () {
   directive.scrollListener = throttle(doCheck.bind(directive), directive.throttleDelay);
   directive.scrollEventTarget.addEventListener('scroll', directive.scrollListener);
 
-  this.vm.$on('hook:beforeDestroy', function () {
-    directive.scrollEventTarget.removeEventListener('scroll', directive.scrollListener);
-  });
+  // this.vm.$on('hook:beforeDestroy', function () {
+  //   directive.scrollEventTarget.removeEventListener('scroll', directive.scrollListener);
+  // });
 
   var disabledExpr = element.getAttribute('infinite-scroll-disabled');
   var disabled = false;
@@ -186,7 +186,7 @@ export default {
       expression: binding.value
     };
     const args = arguments;
-    el[ctx].vm.$on('hook:mounted', function () {
+    // el[ctx].vm.$on('hook:mounted', function () {
       el[ctx].vm.$nextTick(function () {
         if (isAttached(el)) {
           doBind.call(el[ctx], args);
@@ -206,7 +206,7 @@ export default {
 
         tryBind();
       });
-    });
+    // });
   },
 
   unmounted(el) {

--- a/src/directive.js
+++ b/src/directive.js
@@ -182,7 +182,7 @@ export default {
   beforeMount(el, binding, vnode) {
     el[ctx] = {
       el,
-      vm: vnode.context,
+      vm: binding.instance,
       expression: binding.value
     };
     const args = arguments;


### PR DESCRIPTION
* custom directive API changed ([RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0012-custom-directive-api-change.md))
* VNodes are context-free now ([RFC](https://github.com/vuejs/rfcs/blob/render-fn-api-change/active-rfcs/0008-render-function-api-change.md#context-free-vnodes))
* `$on`, `$off` and `$once` instance methods were removed ([RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0020-events-api-change.md)) (and I'm not sure if it was really necessary to use those hooks in the directive in the first place, so just commenting them out for now)